### PR TITLE
Fix player wand

### DIFF
--- a/evaisa.arena/files/scripts/gamemode/gameplay.lua
+++ b/evaisa.arena/files/scripts/gamemode/gameplay.lua
@@ -177,6 +177,12 @@ ArenaGameplay = {
         local current_player = EntityLoad("data/entities/player.xml", 0, 0)
         game_funcs.SetPlayerEntity(current_player)
         np.RegisterPlayerEntityId(current_player)
+
+        -- Mark inventory as initialised, else the game will change the item
+        -- after we've set it in the deserialization.
+        local inventory = EntityGetFirstComponentIncludingDisabled(current_player, "Inventory2Component")
+        ComponentSetValue2(inventory, "mInitialized", true)
+
         player.Deserialize(data.client.serialized_player, (not data.client.player_loaded_from_data))
 
         GameRemoveFlagRun("player_unloaded")
@@ -905,29 +911,6 @@ ArenaGameplay = {
         return ready
     end,
     FightCountdown = function(lobby, data)
-        local playerEntity = player.Get()
-
-        
-        if(playerEntity ~= nil)then
-            local inventory2Comp = EntityGetFirstComponentIncludingDisabled(playerEntity, "Inventory2Component")
-            if(inventory2Comp ~= nil)then
-                ComponentSetValue2(inventory2Comp, "mInitialized", false)
-                ComponentSetValue2(inventory2Comp, "mForceRefresh", true)
-                --[[
-                local activeItem = ComponentGetValue2(playerEntity, "mActiveItem")
-
-                if(activeItem ~= nil)then
-                    local abilityComp = EntityGetFirstComponentIncludingDisabled(activeItem, "AbilityComponent")
-                    if(abilityComp ~= nil)then
-                        ComponentSetValue2(abilityComp, "mReloadFramesLeft", 2)
-                        ComponentSetValue2(abilityComp, "mReloadNextFrameUsable", GameGetFrameNum() + 2)
-                        ComponentSetValue2(abilityComp, "mNextFrameUsable", GameGetFrameNum() + 2)
-                    end
-                end]]
-            end
-        end
-        
-        
         player.Unlock()
         data.countdown = countdown.create({
             "mods/evaisa.arena/files/sprites/ui/countdown/ready.png",
@@ -1141,7 +1124,6 @@ ArenaGameplay = {
         end
     end,
     Update = function(lobby, data)
-        player.TrySetNextFrame()
         --if(GameGetFrameNum() % 60 == 0)then
             --message_handler.send.Handshake(lobby)
         --end

--- a/evaisa.arena/files/scripts/gamemode/helpers/player.lua
+++ b/evaisa.arena/files/scripts/gamemode/helpers/player.lua
@@ -194,23 +194,6 @@ end
 
 set_next_frame = set_next_frame or nil
 
-player_helper.TrySetNextFrame = function()
-    local player = player_helper.Get()
-    if(player == nil)then
-        return
-    end
-
-    if(set_next_frame ~= nil and EntityGetIsAlive(set_next_frame))then
-        game_funcs.SetActiveHeldEntity(player, set_next_frame, true, true)
-        print("Set selected item to: "..tostring(set_next_frame))
-        set_next_frame = nil
-    end
-end
-
-player_helper.SetNextFrame = function(entity)
-    set_next_frame = entity
-end
-
 player_helper.SetWandData = function(wand_data)
     local player = player_helper.Get()
     if(player == nil)then
@@ -251,8 +234,6 @@ player_helper.SetWandData = function(wand_data)
             print("Selected item was: "..tostring(active_item_entity))
 
             game_funcs.SetActiveHeldEntity(player, active_item_entity, false, false)
-            
-            player_helper.SetNextFrame(active_item_entity)
 
             --[[
             local inventory2Comp = EntityGetFirstComponentIncludingDisabled(player, "Inventory2Component")


### PR DESCRIPTION
When `mInitialized` is false in the Inventory2Component, the game selects an item to be held, we don't want this so we set it to true after creating the new player entity.