### PR TITLE
Pause crash workaround

### DIFF
--- a/evaisa.mp/init.lua
+++ b/evaisa.mp/init.lua
@@ -212,7 +212,7 @@ end
 local application_id = 943584660334739457LL
 
 np.InstallShootProjectileFiredCallbacks()
-np.EnableGameSimulatePausing(false)
+--np.EnableGameSimulatePausing(false)
 np.InstallDamageDetailsPatch()
 np.SilenceLogs("Warning - streaming didn\'t find any chunks it could stream away...\n")
 --[[np.EnableExtendedLogging(true)


### PR DESCRIPTION
Seems like some code got inlined and moved around which means the patch to disable pausing no longer works. I couldn't get it working straight away, so I'm just commenting out this line for now.

I think besides this everything should still be working.